### PR TITLE
Prettier Auto Formatting

### DIFF
--- a/test/StarToken.spec.ts
+++ b/test/StarToken.spec.ts
@@ -4,44 +4,63 @@ import { ethers } from "hardhat";
 import { getStarToken } from "../lib/deploy.helpers";
 import { StarToken } from "../typechain";
 
-describe("StarToken Tests", () =>{
-    let starTokenContract: StarToken;
-    let deployer: SignerWithAddress;
-    let acc1: SignerWithAddress;
+describe("StarToken Tests", () => {
+  let starTokenContract: StarToken;
+  let deployer: SignerWithAddress;
+  let acc1: SignerWithAddress;
 
-    const oneStarTokenInWei = ethers.utils.parseEther("1");
-    const MINTER_ROLE = ethers.utils.solidityKeccak256(['string'],['MINTER_ROLE']);
-    const DEFAULT_ADMIN_ROLE = '0x0000000000000000000000000000000000000000000000000000000000000000';
+  const oneStarTokenInWei = ethers.utils.parseEther("1");
+  const MINTER_ROLE = ethers.utils.solidityKeccak256(
+    ["string"],
+    ["MINTER_ROLE"]
+  );
+  const DEFAULT_ADMIN_ROLE =
+    "0x0000000000000000000000000000000000000000000000000000000000000000";
 
+  beforeEach(async () => {
+    starTokenContract = await getStarToken({
+      contractName: "StarToken",
+      deployParams: [],
+    });
+    [deployer, acc1] = await ethers.getSigners();
+  });
 
-    beforeEach(async () => {
-        starTokenContract = await getStarToken({ contractName: "StarToken", deployParams: [] });
-        [deployer, acc1] = await ethers.getSigners();
+  describe("deploy", () => {
+    it("deployer has the DEFAULT_ADMIN_ROLE role", async function () {
+      expect(
+        await starTokenContract.hasRole(
+          DEFAULT_ADMIN_ROLE,
+          deployer.address.toLowerCase()
+        )
+      ).to.be.true;
     });
 
+    it("non-deployer to not have DEFAULT_ADMIN_ROLE role", async function () {
+      expect(
+        await starTokenContract.hasRole(
+          DEFAULT_ADMIN_ROLE,
+          acc1.address.toLowerCase()
+        )
+      ).to.be.false;
+    });
+  });
 
-    describe("deploy", () => {
-        it('deployer has the DEFAULT_ADMIN_ROLE role', async function () {
-            expect(await starTokenContract.hasRole(DEFAULT_ADMIN_ROLE, deployer.address.toLowerCase())).to.be.true;
-        });
+  describe("mint", () => {
+    it("Should revert if the caller does not have minter role", async () => {
+      await expect(
+        starTokenContract
+          .connect(acc1)
+          .mint(deployer.address, oneStarTokenInWei)
+      ).to.be.revertedWith(
+        `AccessControl: account ${acc1.address.toLowerCase()} is missing role ${MINTER_ROLE.toLowerCase()}`
+      );
+    });
 
-        it('non-deployer to not have DEFAULT_ADMIN_ROLE role', async function () {
-            expect(await starTokenContract.hasRole(DEFAULT_ADMIN_ROLE, acc1.address.toLowerCase())).to.be.false;
-        });
-    })
+    it("Should work when called by the owner", async () => {
+      await starTokenContract.mint(deployer.address, oneStarTokenInWei);
 
-    describe("mint", () => {
-        it("Should revert if the caller does not have minter role", async () => {
-            await expect(
-                starTokenContract.connect(acc1).mint(deployer.address, oneStarTokenInWei)
-            ).to.be.revertedWith(`AccessControl: account ${acc1.address.toLowerCase()} is missing role ${MINTER_ROLE.toLowerCase()}`);
-          });
-
-        it("Should work when called by the owner", async () => {
-        await starTokenContract.mint(deployer.address, oneStarTokenInWei);
-
-        const balance = await starTokenContract.balanceOf(deployer.address);
-        expect(balance).to.equal(oneStarTokenInWei);
-        });    
-    })
+      const balance = await starTokenContract.balanceOf(deployer.address);
+      expect(balance).to.equal(oneStarTokenInWei);
+    });
+  });
 });


### PR DESCRIPTION
Since this hardhat scaffolding comes with a `.prettierrc` file, my Prettier VSCode plugin is showing warnings all over this file and it's also set to autoformat files on save. Do you mind if I merge this formatting change @sstrgh ? If we all setup the prettier plugin to format on save then we can all have the same code style. The hardhat scaffolding also uses prettier to autoformat solidity code which is pretty cool too.

Quick install if you don't already have it. The follow directions to set formatOnSave.
https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode